### PR TITLE
Add flexible column mappings to reconciliation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Reconciliation Starter
+
+This repository contains a small Python script to reconcile bank transactions with your practice management ledger.
+
+## Usage
+
+Provide two Excel files:
+1. **Bank file** – the transactions received by the bank.
+2. **Practice file** – the payments recorded in your practice system.
+
+Both files should include a reference column (for example an invoice or patient ID) and an amount column. If the column names differ between the bank and practice files you can specify them on the command line.
+
+Run the script:
+
+```bash
+python reconcile.py bank.xlsx practice.xlsx report.xlsx
+```
+
+The resulting `report.xlsx` lists each reference with the amounts found in the bank and practice files and a status column showing whether the payments match or if one is missing.
+
+### Column Options
+
+Specify the column names for each file individually:
+
+```bash
+python reconcile.py bank.xlsx practice.xlsx report.xlsx \
+  --bank-reference BankRef --practice-reference InvoiceID \
+  --bank-amount Received --practice-amount Paid
+```
+
+### Requirements
+
+- Python 3
+- `pandas` library (install via `pip install pandas openpyxl`)
+

--- a/reconcile.py
+++ b/reconcile.py
@@ -1,0 +1,91 @@
+import argparse
+import pandas as pd
+
+
+def load_excel(path: str) -> pd.DataFrame:
+    """Load an Excel file into a DataFrame with empty strings replaced by NaN."""
+    df = pd.read_excel(path)
+    df = df.dropna(how="all")
+    df = df.fillna("")
+    return df
+
+
+def normalize_amount(series: pd.Series) -> pd.Series:
+    """Convert amount strings to floats."""
+    return pd.to_numeric(series, errors="coerce").fillna(0)
+
+
+def reconcile(
+    bank_df: pd.DataFrame,
+    practice_df: pd.DataFrame,
+    bank_ref: str = "Reference",
+    practice_ref: str = "Reference",
+    bank_amount: str = "Amount",
+    practice_amount: str = "Amount",
+) -> pd.DataFrame:
+    """Return a reconciliation DataFrame merging bank and practice by reference."""
+    bank_df = bank_df.copy()
+    practice_df = practice_df.copy()
+
+    bank_df[bank_amount] = normalize_amount(bank_df[bank_amount])
+    practice_df[practice_amount] = normalize_amount(practice_df[practice_amount])
+
+    bank_df.rename(columns={bank_ref: "Reference", bank_amount: "Amount_bank"}, inplace=True)
+    practice_df.rename(columns={practice_ref: "Reference", practice_amount: "Amount_practice"}, inplace=True)
+
+    merged = pd.merge(
+        bank_df,
+        practice_df,
+        on="Reference",
+        how="outer",
+        indicator=True,
+    )
+
+    def status(row):
+        if row["_merge"] == "both":
+            if row["Amount_bank"] == row["Amount_practice"]:
+                return "matched"
+            else:
+                return "amount_mismatch"
+        elif row["_merge"] == "left_only":
+            return "missing_in_practice"
+        else:
+            return "missing_in_bank"
+
+    merged["status"] = merged.apply(status, axis=1)
+    merged.drop(columns=["_merge"], inplace=True)
+    return merged
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Reconcile bank and practice Excel files")
+    parser.add_argument("bank", help="Bank transactions Excel file")
+    parser.add_argument("practice", help="Practice payments Excel file")
+    parser.add_argument("output", help="Output Excel file with reconciliation report")
+    parser.add_argument("--bank-reference", default="Reference",
+                        help="Reference column in the bank file")
+    parser.add_argument("--practice-reference", default="Reference",
+                        help="Reference column in the practice file")
+    parser.add_argument("--bank-amount", default="Amount",
+                        help="Amount column in the bank file")
+    parser.add_argument("--practice-amount", default="Amount",
+                        help="Amount column in the practice file")
+    args = parser.parse_args()
+
+    bank_df = load_excel(args.bank)
+    practice_df = load_excel(args.practice)
+
+    result = reconcile(
+        bank_df,
+        practice_df,
+        bank_ref=args.bank_reference,
+        practice_ref=args.practice_reference,
+        bank_amount=args.bank_amount,
+        practice_amount=args.practice_amount,
+    )
+    result.to_excel(args.output, index=False)
+    print(f"Reconciliation written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow specifying different reference and amount column names for bank and practice files
- update README with new CLI options

## Testing
- `pip install pandas openpyxl`
- `python reconcile.py bank_custom.xlsx practice_custom.xlsx reconcile_custom.xlsx --bank-reference BankRef --practice-reference InvoiceID --bank-amount Received --practice-amount Paid`
- `python reconcile.py example_bank.xlsx example_practice.xlsx output.xlsx --bank-reference Reference --practice-reference Reference --bank-amount Amount --practice-amount Amount`

------
https://chatgpt.com/codex/tasks/task_e_68885cd2f3948323b2bc0093e05aeabe